### PR TITLE
fix empty init

### DIFF
--- a/metricbeat/init.sls
+++ b/metricbeat/init.sls
@@ -1,0 +1,4 @@
+include:
+  - metricbeat.repo
+  - metricbeat.install
+  - metricbeat.service


### PR DESCRIPTION
I published this without running the code first. Eeeek!

This makes `metricbeat` state work as expected.